### PR TITLE
Download SAML assertion certificate from the Curity Identity Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 node_modules
-default-signature-verification-key.pem
 download
 mssql-data
 cdb

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ export LICENSE_FILE_PATH=~/Desktop/license-trial.json
 ```
 
 Sign in to the Admin UI at `https://localhost:6749/admin` with credentials `admin / Password1`.\
-Use the facilities menu to export the certificate of the default signature verification key.\
-Save it to the root folder of this project with the name `default-signature-verification-key.pem`.
+Use the facilities menu to view the certificate of the default signature verification key.\
+The website downloads this certificate from the SAML metadata endpoint to validate SAML assertions.
 
 ### View Stored User Accounts
 

--- a/idsvr/deploy.sh
+++ b/idsvr/deploy.sh
@@ -33,6 +33,11 @@ if [ $? -ne 0 ]; then
 fi
 
 #
+# This example forces recreation of the configuration database on every deployment
+#
+rm -rf cdb && mkdir cdb && chmod 777 cdb
+
+#
 # This example forces recreation of database data on every deployment
 #
 rm -rf mssql-data && mkdir mssql-data && chmod 777 mssql-data

--- a/idsvr/docker-compose.yml
+++ b/idsvr/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: curity.azurecr.io/curity/idsvr:latest
     hostname: idsvr
     volumes:
+    - ./cdb:/opt/idsvr/var/cdb
     - ./curity-config.xml:/opt/idsvr/etc/init/curity-config.xml
     ports:
     - 6749:6749

--- a/idsvr/docker-compose.yml
+++ b/idsvr/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     image: curity.azurecr.io/curity/idsvr:latest
     hostname: idsvr
     volumes:
-    - ./cdb:/opt/idsvr/var/cdb
     - ./curity-config.xml:/opt/idsvr/etc/init/curity-config.xml
     ports:
     - 6749:6749

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
                 "ejs": "^3.1.10",
                 "express": "^5.1.0",
                 "express-session": "^1.18.2",
-                "passport": "^0.7.0"
+                "passport": "^0.7.0",
+                "xml-js": "^1.6.11"
             },
             "devDependencies": {
                 "@types/express": "^5.0.3",
@@ -1884,6 +1885,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6.0"
+            }
+        },
+        "node_modules/xml-js": {
+            "version": "1.6.11",
+            "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+            "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+            "license": "MIT",
+            "dependencies": {
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "xml-js": "bin/cli.js"
             }
         },
         "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -12,18 +12,19 @@
     "scripts": {
         "start": "./start.sh"
     },
-    "devDependencies": {
-        "@types/express": "^5.0.3",
-        "@types/express-session": "^1.18.2",
-        "tsx": "^4.20.3",
-        "typescript": "^5.9.2"
-    },
     "dependencies": {
         "@node-saml/passport-saml": "^5.1.0",
         "@types/passport-saml": "^1.1.7",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "express-session": "^1.18.2",
-        "passport": "^0.7.0"
+        "passport": "^0.7.0",
+        "xml-js": "^1.6.11"
+    },
+    "devDependencies": {
+        "@types/express": "^5.0.3",
+        "@types/express-session": "^1.18.2",
+        "tsx": "^4.20.3",
+        "typescript": "^5.9.2"
     }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -9,7 +9,6 @@ export class Configuration {
     public callbackUrl: string;
     public entityId: string;
     public cookieSecret: string;
-    public assertionVerificationCertificate: string;
 
     public constructor() {
         this.port = this.getValue('PORT');
@@ -18,7 +17,6 @@ export class Configuration {
         this.entityId = this.getValue('ENTITY_ID');
         this.callbackUrl = this.getValue('CALLBACK_URL');
         this.cookieSecret = this.getValue('COOKIE_SECRET');
-        this.assertionVerificationCertificate = this.getValue('ASSERTION_VERIFICATION_CERTIFICATE');
     }
 
     public isHttps(): boolean {

--- a/start.sh
+++ b/start.sh
@@ -3,15 +3,6 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 #
-# Load the SAML verification certificate for the Curity Identity Server
-#
-if [ ! -f default-signature-verification-key.pem ]; then
-  echo 'Please copy a default-signing-key.pem file into the root folder before running the application'
-  exit 1
-fi
-export ASSERTION_VERIFICATION_CERTIFICATE=$(cat default-signature-verification-key.pem)
-
-#
 # Create a high entropy secret with which express-session signs cookies
 #
 export COOKIE_SECRET=$(openssl rand 32 | xxd -p -c 64)


### PR DESCRIPTION
Use the 10.4.1 fix to get the SAML assertion certificate from SAML metadata.